### PR TITLE
Add grid cell toggling and stacking controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # Game_zeros_gpt
-Play area. X-ray scanner.
+
+A simple experiment with the [Arcade](https://api.arcade.academy/) library.
+The window displays a blue grid of cells. Use the keyboard to explore and
+manipulate the board.
+
+## Controls
+- Arrow keys – move the yellow cursor across the grid.
+- Space – toggle the selected cell between blue and green.
+- PageUp / PageDown – move to upper or lower stacked grid layers.
+
+## Running
+```bash
+pip install -r requirements.txt
+python main.py
+```
+The script uses headless mode so it can run in environments without a
+physical display.

--- a/main.py
+++ b/main.py
@@ -1,18 +1,109 @@
-import os; os.environ.setdefault("PYGLET_HEADLESS","True")
+import os
+os.environ.setdefault("PYGLET_HEADLESS", "True")
+
 import arcade
 
-W,H=600,600; CELL=60
-class App(arcade.Window):
-    def __init__(self): super().__init__(W,H,"Grid"); self.cx=self.cy=0
-    def on_draw(self):
-        self.clear()
-        for x in range(0,W+1,CELL): arcade.draw_line(x,0,x,H,arcade.color.GRAY)
-        for y in range(0,H+1,CELL): arcade.draw_line(0,y,W,y,arcade.color.GRAY)
-        arcade.draw_rectangle_outline(self.cx*CELL+CELL/2,self.cy*CELL+CELL/2,
-                                      CELL,CELL,arcade.color.YELLOW,3)
-    def on_key_press(self,key,mod):
-        if key==arcade.key.RIGHT and self.cx< W//CELL-1: self.cx+=1
-        if key==arcade.key.LEFT  and self.cx>0: self.cx-=1
-        if key==arcade.key.UP    and self.cy< H//CELL-1: self.cy+=1
-        if key==arcade.key.DOWN  and self.cy>0: self.cy-=1
-if __name__=="__main__": arcade.run()
+WINDOW_WIDTH = 600
+WINDOW_HEIGHT = 600
+CELL_SIZE = 60
+GRID_COLOR_BLUE = arcade.color.BLUE
+GRID_COLOR_GREEN = arcade.color.GREEN
+HIGHLIGHT_COLOR = arcade.color.YELLOW
+
+
+class GridApp(arcade.Window):
+    """Simple grid where cells can be toggled between blue and green.
+
+    Arrow keys move a cursor. Press SPACE to toggle the color of the
+    highlighted cell. PAGEUP and PAGEDOWN move between stacked grid layers.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(WINDOW_WIDTH, WINDOW_HEIGHT, "Grid")
+        self.cols = WINDOW_WIDTH // CELL_SIZE
+        self.rows = WINDOW_HEIGHT // CELL_SIZE
+        self.cx = 0
+        self.cy = 0
+        self.layers = [self._create_layer()]
+        self.current_layer = 0
+        arcade.set_background_color(arcade.color.BLACK)
+
+    def _create_layer(self):
+        return [
+            [GRID_COLOR_BLUE for _ in range(self.cols)]
+            for _ in range(self.rows)
+        ]
+
+    def on_draw(self) -> None:
+        """Render stacked grids and highlight the cursor."""
+        arcade.start_render()
+        for idx, layer in enumerate(self.layers):
+            offset = idx * 5
+            for row in range(self.rows):
+                for col in range(self.cols):
+                    color = layer[row][col]
+                    x = col * CELL_SIZE + CELL_SIZE / 2
+                    y = row * CELL_SIZE + CELL_SIZE / 2 + offset
+                    arcade.draw_rectangle_filled(
+                        x, y, CELL_SIZE, CELL_SIZE, color
+                    )
+                    arcade.draw_rectangle_outline(
+                        x, y, CELL_SIZE, CELL_SIZE, arcade.color.GRAY
+                    )
+
+        x = self.cx * CELL_SIZE + CELL_SIZE / 2
+        y = self.cy * CELL_SIZE + CELL_SIZE / 2 + self.current_layer * 5
+        arcade.draw_rectangle_outline(
+            x, y, CELL_SIZE, CELL_SIZE, HIGHLIGHT_COLOR, 3
+        )
+        arcade.draw_text(
+            f"Layer: {self.current_layer}",
+            10,
+            WINDOW_HEIGHT - 20,
+            arcade.color.WHITE,
+            12,
+        )
+
+    def on_key_press(self, key, modifiers) -> None:
+        if key == arcade.key.RIGHT and self.cx < self.cols - 1:
+            self.cx += 1
+        elif key == arcade.key.LEFT and self.cx > 0:
+            self.cx -= 1
+        elif key == arcade.key.UP and self.cy < self.rows - 1:
+            self.cy += 1
+        elif key == arcade.key.DOWN and self.cy > 0:
+            self.cy -= 1
+        elif key == arcade.key.SPACE:
+            self._toggle_cell()
+        elif key == arcade.key.PAGEUP:
+            self._raise_layer()
+        elif key == arcade.key.PAGEDOWN:
+            self._lower_layer()
+
+    def _toggle_cell(self) -> None:
+        """Toggle color of the cell under the cursor."""
+        layer = self.layers[self.current_layer]
+        color = layer[self.cy][self.cx]
+        layer[self.cy][self.cx] = (
+            GRID_COLOR_GREEN if color == GRID_COLOR_BLUE else GRID_COLOR_BLUE
+        )
+
+    def _raise_layer(self) -> None:
+        """Move up to a higher layer, creating one if needed."""
+        self.current_layer += 1
+        if self.current_layer >= len(self.layers):
+            self.layers.append(self._create_layer())
+
+    def _lower_layer(self) -> None:
+        """Move down to a lower layer if possible."""
+        if self.current_layer > 0:
+            self.current_layer -= 1
+
+
+def main() -> None:
+    GridApp()
+    arcade.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-arcade==2.6.17        # или pygame==2.6.0
+arcade==2.6.17
 pytest


### PR DESCRIPTION
## Summary
- Implement Arcade-based grid with selectable blue cells that can toggle to green
- Allow moving between stacked grid layers with PageUp/PageDown
- Document controls and setup in README

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a7f5c5ac832fa959244e507095ef